### PR TITLE
fix: widget asks for the correct access level

### DIFF
--- a/organigramme/api.js
+++ b/organigramme/api.js
@@ -50,7 +50,7 @@ function ready(fn) {
 
 ready(function () {
 
-  grist.ready({ requiredAccess: 'none', columns: columnsMappingOptions });
+  grist.ready({ requiredAccess: 'read table', columns: columnsMappingOptions });
 
   grist.onRecords((table, mappings) => {
     //document.getElementById('dump').innerHTML = JSON.stringify(table, null, 2);


### PR DESCRIPTION
this is so users know that the widget needs to be granted read-only access to the tables